### PR TITLE
max_idle_time parsed as float

### DIFF
--- a/torndb.py
+++ b/torndb.py
@@ -66,7 +66,7 @@ class Connection(object):
                  time_zone="+0:00"):
         self.host = host
         self.database = database
-        self.max_idle_time = max_idle_time
+        self.max_idle_time = float(max_idle_time)
 
         args = dict(conv=CONVERSIONS, use_unicode=True, charset="utf8",
                     db=database, init_command=('SET time_zone = "%s"' % time_zone),


### PR DESCRIPTION
I frequently construct via:

``` python
torndb.Connection(**re.search("mysql://(?P<user>\w+):(?P<password>\w*)@(?P<host>.*)/(?P<database>[\w\-]+)\?reconnect=true&max_idle_time=(?P<max_idle_time>\d+)",
    "mysq://user:pass@host/database?reconnect=true&max_idle_time=60").groupdict())
```

But `max_idle_time` gets parsed as a string, not a float. So adding the `float(max_idle_time)` will make this method possible.
