### PR TITLE
Fix bug about passing empty args into execute function for MySQLdb

### DIFF
--- a/torndb.py
+++ b/torndb.py
@@ -231,7 +231,7 @@ class Connection(object):
 
     def _execute(self, cursor, query, parameters, kwparameters):
         try:
-            return cursor.execute(query, kwparameters or parameters)
+            return cursor.execute(query, kwparameters or parameters or None)
         except OperationalError:
             logging.error("Error connecting to MySQL on %s", self.host)
             self.close()


### PR DESCRIPTION
Ensure correct SQL can be executed when no extra parameters passed.

The key point: [https://github.com/farcepest/MySQLdb1/blob/master/MySQLdb/cursors.py#L164](https://github.com/farcepest/MySQLdb1/blob/master/MySQLdb/cursors.py#L164)

If pass the same SQL query that contains '%' character into `MySQLdb.cursor.execute` and `torndb.db.insert`:

```
    sql = "INSERT INTO demo(name) VALUES('%E6%88%BF%E7%A5%96%E5%90')"

    print "SQL for MySQLdb"
    cursor.execute(sql)
    print "SQL for torndb"
    db.insert(sql)
```

Success for the 1st, but failed for the 2nd

```
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/john/workspace/sohu/seorank/seorank/searchresult.py", line 166, in <module>
    parse_baidu_search_page(searchpage, keyword, pagenum)
  File "/Users/john/workspace/sohu/seorank/seorank/searchresult.py", line 126, in parse_baidu_search_page
    result.save()
  File "seorank/models.py", line 55, in save
    db.insert(sql)
  File "/Users/john/.virtualenvs/seo/lib/python2.7/site-packages/torndb.py", line 166, in execute_lastrowid
    self._execute(cursor, query, parameters, kwparameters)
  File "/Users/john/.virtualenvs/seo/lib/python2.7/site-packages/torndb.py", line 234, in _execute
    return cursor.execute(query, kwparameters or parameters)
  File "/Users/john/.virtualenvs/seo/lib/python2.7/site-packages/MySQLdb/cursors.py", line 187, in execute
    query = query % tuple([db.literal(item) for item in args])
TypeError: not enough arguments for format string
```
