### PR TITLE
Don't use izip, fixes #26

### DIFF
--- a/torndb.py
+++ b/torndb.py
@@ -24,7 +24,6 @@ as torndb.
 from __future__ import absolute_import, division, with_statement
 
 import copy
-import itertools
 import logging
 import os
 import time
@@ -139,7 +138,7 @@ class Connection(object):
         try:
             self._execute(cursor, query, parameters, kwparameters)
             column_names = [d[0] for d in cursor.description]
-            return [Row(itertools.izip(column_names, row)) for row in cursor]
+            return [Row(zip(column_names, row)) for row in cursor]
         finally:
             cursor.close()
 


### PR DESCRIPTION
In Python 3 `zip` is like `izip` in Python 2. There doesn't seem to be an actual need for using `izip` in the code, as `zip` is used  in similar code 10 lines above.