### PR TITLE
Add `delete` alias for `execute_rowcount`

### DIFF
--- a/torndb.py
+++ b/torndb.py
@@ -211,7 +211,7 @@ class Connection(object):
         finally:
             cursor.close()
 
-    update = execute_rowcount
+    update = delete = execute_rowcount
     updatemany = executemany_rowcount
 
     insert = execute_lastrowid


### PR DESCRIPTION
Alias for `delete` would be as helpful as aliases for existing `update` and `insert`.