### PR TITLE
Fallback to pymysql

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Limitations
 -----------
 
 Torndb does not support Python 3, or any database drivers other than
-`MySQLdb`.
+`MySQLdb` or `pymysql`.
 
 Installation
 ------------

--- a/torndb.py
+++ b/torndb.py
@@ -33,13 +33,16 @@ try:
     import MySQLdb.converters
     import MySQLdb.cursors
 except ImportError:
-    # If MySQLdb isn't available this module won't actually be useable,
-    # but we want it to at least be importable on readthedocs.org,
-    # which has limitations on third-party modules.
-    if 'READTHEDOCS' in os.environ:
-        MySQLdb = None
-    else:
-        raise
+    try:
+        import pymysql as MySQLdb
+    except ImportError:
+        # If MySQLdb isn't available this module won't actually be useable,
+        # but we want it to at least be importable on readthedocs.org,
+        # which has limitations on third-party modules.
+        if 'READTHEDOCS' in os.environ:
+            MySQLdb = None
+        else:
+            raise
 
 version = "0.3"
 version_info = (0, 3, 0, 0)


### PR DESCRIPTION
This allows torndb to fallback to pymysql which is pure Python and does not require compilation or mysql headers.
