### PR TITLE
fixed a bug of Row class

### DIFF
--- a/torndb.py
+++ b/torndb.py
@@ -245,7 +245,7 @@ class Connection(object):
 
 
 class Row():
-    """A dict that allows for object-like property access syntax."""
+    """A dict similar that allows for object-like property access syntax."""
     def __init__(self, data):
         if isinstance(data, list):
             self._dict = dict(data)

--- a/torndb.py
+++ b/torndb.py
@@ -246,9 +246,23 @@ class Connection(object):
 
 class Row(dict):
     """A dict that allows for object-like property access syntax."""
+    def __init__(self, data):
+        if isinstance(data, list):
+            self._dict = dict(data)
+        elif isinstance(data, dict):
+            self._dict = data
+        else:
+            self._dict = {}
+
+    def __getitem__(self, name):
+        try:
+            return self._dict[name]
+        except KeyError:
+            raise AttributeError(name)
+ 
     def __getattr__(self, name):
         try:
-            return self[name]
+            return self._dict[name]
         except KeyError:
             raise AttributeError(name)
 

--- a/torndb.py
+++ b/torndb.py
@@ -244,7 +244,7 @@ class Connection(object):
             raise
 
 
-class Row(dict):
+class Row():
     """A dict that allows for object-like property access syntax."""
     def __init__(self, data):
         if isinstance(data, list):


### PR DESCRIPTION
If a field of a table is the same as the `items` or another class variable of built-in python-dict, then the result of `Row.items ` is not expected . Therefore, it is recommended to modify the Row class, do not extend dict, just implement the Row class which is similar to dict.